### PR TITLE
[ID] Check extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2257,7 +2257,7 @@ dependencies = [
 
 [[package]]
 name = "engine"
-version = "26.6.6+2406175"
+version = "26.6.6+d0f63e9"
 dependencies = [
  "approx",
  "burn",
@@ -4019,7 +4019,7 @@ dependencies = [
 
 [[package]]
 name = "nephrid"
-version = "26.6.6+2406175"
+version = "26.6.6+d0f63e9"
 dependencies = [
  "assert_cmd",
  "engine",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "engine"
-version = "26.6.6+2406175"
+version = "26.6.6+d0f63e9"
 edition = "2024"
 
 [dependencies]

--- a/engine/src/core/search/id/mod.rs
+++ b/engine/src/core/search/id/mod.rs
@@ -11,7 +11,7 @@ use crate::{
         move_iter::fold_legal_moves,
         params::HceParams,
         ply::Ply,
-        position::Position,
+        position::{CheckState, Position},
         search::{
             id::node_types::*,
             limit::UciLimit,
@@ -306,11 +306,21 @@ impl Searcher {
             // make the move
             pos.make_move_for::<P>(m);
 
+            // depth extensions
+            let mut depth_extension = 0;
+
+            // check extensions
+            if pos.get_check_state() != CheckState::None {
+                depth_extension += 1;
+            }
+
             // recurse
             let score = {
+                let new_depth = depth - 1 + depth_extension;
+
                 if i == 0 {
                     // search with a full window to get an exact score.
-                    !self.search::<P::Opponent, Normal>(pos, stats, depth - 1, !beta, !alpha)
+                    !self.search::<P::Opponent, Normal>(pos, stats, new_depth, !beta, !alpha)
                 }
                 else {
                     // assume that our move ordering is good the first move will be the best one.
@@ -320,7 +330,7 @@ impl Searcher {
                     let zws_score = !self.search::<P::Opponent, Normal>(
                         pos,
                         stats,
-                        depth - 1,
+                        new_depth,
                         !(alpha + Score::new(1)),
                         !alpha,
                     );
@@ -331,10 +341,7 @@ impl Searcher {
                         && zws_score < beta
                     {
                         !self.search::<P::Opponent, Normal>(
-                            pos,
-                            stats,
-                            depth - 1,
-                            !beta,
+                            pos, stats, new_depth, !beta,
                             // new lower_bound, since it was able to beat alpha
                             !zws_score,
                         )

--- a/nephrid/Cargo.toml
+++ b/nephrid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nephrid"
-version = "26.6.6+2406175"
+version = "26.6.6+d0f63e9"
 edition = "2024"
 
 [features]


### PR DESCRIPTION
Score of ccbench/in/builds/nephrid-fb7b06e vs
ccbench/in/builds/nephrid-2cad6e9: 347 - 230 - 175  [0.578] 752
...      ccbench/in/builds/nephrid-fb7b06e playing White: 182 - 110 - 86
[0.595] 378
...      ccbench/in/builds/nephrid-fb7b06e playing Black: 165 - 120 - 89
[0.560] 374
...      White vs Black: 302 - 275 - 175  [0.518] 752
Elo difference: 54.5 +/- 21.9, LOS: 100.0 %, DrawRatio: 23.3 %
SPRT: llr 0.869 (29.5%), lbound -2.94, ubound 2.94

Player: ccbench/in/builds/nephrid-fb7b06e
   "Draw by 3-fold repetition": 110
   "Draw by fifty moves rule": 18
   "Draw by insufficient mating material": 44
   "Draw by stalemate": 3
   "Loss: Black mates": 109
   "Loss: White disconnects": 1
   "Loss: White mates": 120
   "No result": 4
   "Win: Black disconnects": 1
   "Win: Black mates": 165
   "Win: White mates": 181
Player: ccbench/in/builds/nephrid-2cad6e9
   "Draw by 3-fold repetition": 110
   "Draw by fifty moves rule": 18
   "Draw by insufficient mating material": 44
   "Draw by stalemate": 3
   "Loss: Black disconnects": 1
   "Loss: Black mates": 165
   "Loss: White mates": 181
   "No result": 4
   "Win: Black mates": 109
   "Win: White disconnects": 1
   "Win: White mates": 120
Finished match