### PR TITLE
[ID] LMR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2257,7 +2257,7 @@ dependencies = [
 
 [[package]]
 name = "engine"
-version = "26.6.6+d0f63e9"
+version = "26.6.6+0058816"
 dependencies = [
  "approx",
  "burn",
@@ -4019,7 +4019,7 @@ dependencies = [
 
 [[package]]
 name = "nephrid"
-version = "26.6.6+d0f63e9"
+version = "26.6.6+0058816"
 dependencies = [
  "assert_cmd",
  "engine",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "engine"
-version = "26.6.6+d0f63e9"
+version = "26.6.6+0058816"
 edition = "2024"
 
 [dependencies]

--- a/engine/src/core/search/id/mod.rs
+++ b/engine/src/core/search/id/mod.rs
@@ -306,12 +306,22 @@ impl Searcher {
             // make the move
             pos.make_move_for::<P>(m);
 
-            // depth extensions
+            // depth
             let mut depth_extension = 0;
+            let mut depth_reduction = 0;
+            let gives_check = pos.get_check_state() != CheckState::None;
 
             // check extensions
-            if pos.get_check_state() != CheckState::None {
+            if gives_check {
                 depth_extension += 1;
+            }
+
+            // late move reductions
+            if depth >= Depth::new(3) && i > 1 {
+                let d = depth.v() as f32;
+                let m = i as f32;
+                let lmr = 0.99 + f32::ln(d) * f32::ln(m) / 3.14;
+                depth_reduction += lmr as u8;
             }
 
             // recurse
@@ -327,13 +337,28 @@ impl Searcher {
                     // to prove that this move cannot improve our first move, perform a zero window
                     // search with [a,a+1] (~ [-(a-1),-a]). we don't care by how much this move is
                     // able to improve alpha since we assume that it cannot.
-                    let zws_score = !self.search::<P::Opponent, Normal>(
+                    let mut zws_score = !self.search::<P::Opponent, Normal>(
                         pos,
                         stats,
-                        new_depth,
+                        // scout with a reduced depth
+                        new_depth - depth_reduction,
                         !(alpha + Score::new(1)),
                         !alpha,
                     );
+
+                    // if the reduced depth search fails high, we must verify that it is actually
+                    // good and do a full depth re-search.
+                    if zws_score > alpha && depth_reduction > 0 {
+                        zws_score = !self.search::<P::Opponent, Normal>(
+                            pos,
+                            stats,
+                            // research at full depth
+                            new_depth,
+                            // still zero-window.
+                            !(alpha + Score::new(1)),
+                            !alpha,
+                        );
+                    }
 
                     // if zws_score is a lower_bound, we have to research to get an exact score.
                     if zws_score > alpha

--- a/engine/src/core/search/id/mod.rs
+++ b/engine/src/core/search/id/mod.rs
@@ -317,6 +317,7 @@ impl Searcher {
             }
 
             // late move reductions
+            #[allow(clippy::approx_constant)]
             if depth >= Depth::new(3) && i > 1 {
                 let d = depth.v() as f32;
                 let m = i as f32;

--- a/nephrid/Cargo.toml
+++ b/nephrid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nephrid"
-version = "26.6.6+d0f63e9"
+version = "26.6.6+0058816"
 edition = "2024"
 
 [features]


### PR DESCRIPTION
ccbench:
```
Score of ccbench/in/builds/nephrid-cbf4764 vs ccbench/in/builds/nephrid-6c3ab39: 171 - 56 - 78  [0.689] 305
...      ccbench/in/builds/nephrid-cbf4764 playing White: 84 - 25 - 44  [0.693] 153
...      ccbench/in/builds/nephrid-cbf4764 playing Black: 87 - 31 - 34  [0.684] 152
...      White vs Black: 115 - 112 - 78  [0.505] 305
Elo difference: 137.8 +/- 35.4, LOS: 100.0 %, DrawRatio: 25.6 %
SPRT: llr 0.942 (32.0%), lbound -2.94, ubound 2.94

Player: ccbench/in/builds/nephrid-cbf4764
   "Draw by 3-fold repetition": 45
   "Draw by fifty moves rule": 13
   "Draw by insufficient mating material": 20
   "Loss: Black mates": 25
   "Loss: White mates": 31
   "No result": 6
   "Win: Black mates": 87
   "Win: White mates": 84
Player: ccbench/in/builds/nephrid-6c3ab39
   "Draw by 3-fold repetition": 45
   "Draw by fifty moves rule": 13
   "Draw by insufficient mating material": 20
   "Loss: Black mates": 87
   "Loss: White mates": 84
   "No result": 6
   "Win: Black mates": 25
   "Win: White mates": 31
Finished match
```