### PR TITLE
Add movestream chrono soft target

### DIFF
--- a/engine/src/core/chrono.rs
+++ b/engine/src/core/chrono.rs
@@ -11,7 +11,12 @@ use crate::{
 pub const trait ChronoParams {
     /// Fraction of the maximum possible root entropy below which the engine is
     /// considered confident enough to stop searching early.
+    #[deprecated(
+        note = "Elo improves but sometimes the engine blunders when a move on depth 1 looks like the only promising one. Not using this for now."
+    )]
     fn entropy_target(&self) -> NormalizedEntropy;
+
+    fn movestreak_target(&self) -> u32;
 }
 
 #[derive(Debug)]
@@ -28,11 +33,18 @@ pub struct TimeMan {
     /// Soft bound: stop once the current root entropy drops to/below this.
     entropy_target: NormalizedEntropy,
 
+    /// Soft bound: stop once the one move has been the best for x times in a
+    /// row.
+    movestreak_target: u32,
+
     /// Time allocated per move
     time_per_move: Duration,
 
     /// Curr Stats
     curr_entropy: NormalizedEntropy,
+
+    /// Current move streak
+    curr_movestreak: u32,
 }
 
 impl TimeMan {
@@ -50,10 +62,12 @@ impl TimeMan {
             time_target: time_limit,
 
             entropy_target: NormalizedEntropy::zero(),
+            movestreak_target: u32::MAX,
 
             time_per_move,
 
             curr_entropy: NormalizedEntropy::one(),
+            curr_movestreak: 0,
         }
     }
 
@@ -86,18 +100,17 @@ impl TimeMan {
     pub fn reached_target(&self) -> bool {
         let curr_time = Instant::now();
 
-        curr_time >= self.time_target || self.curr_entropy.v() <= self.entropy_target.v()
+        curr_time >= self.time_target || self.curr_entropy.v() <= self.entropy_target.v() || self.curr_movestreak >= self.movestreak_target
     }
 
     pub fn set_curr_entropy(&mut self, entropy: NormalizedEntropy) { self.curr_entropy = entropy; }
+    pub fn set_curr_movestreak(&mut self, movestreak: u32) { self.curr_movestreak = movestreak; }
 
     pub fn hint_entropy_target(&mut self, entropy: NormalizedEntropy) { self.entropy_target = entropy; }
-
+    pub fn hint_movestreak_target(&mut self, movestreak: u32) { self.movestreak_target = movestreak; }
     pub fn hint_time_target(&mut self, time: Instant) { self.time_target = time; }
 
     pub fn time_start(&self) -> Instant { self.time_start }
-
     pub fn time_limit(&self) -> Instant { self.time_limit }
-
     pub fn search_time(&self) -> Duration { Instant::now() - self.time_start }
 }

--- a/engine/src/core/config.rs
+++ b/engine/src/core/config.rs
@@ -316,6 +316,9 @@ pub struct Configuration {
     /// Target entropy for time management.
     timeman_entropy_target: ConfigOption<Spin<UciPercent>>,
 
+    /// Target move streak for time management.
+    timeman_movestreak_target: ConfigOption<Spin<UciInteger>>,
+
     /// [Iterative Deepening] Null Move Pruning reduction (R).
     id_nmp_reduction: ConfigOption<Spin<UciInteger>>,
 
@@ -368,6 +371,7 @@ impl Configuration {
                 mcts_killer_exploitation: ConfigOption::new("mcts-killer-exploitation", Spin::<UciPercent>::new(_ratio(0.27), _ratio(0.), _ratio(10.))),
                 mcts_tt_best_move: ConfigOption::new("mcts-tt-best-move", Spin::<UciPercent>::new(_ratio(1.50), _ratio(0.), _ratio(10.))),
                 timeman_entropy_target: ConfigOption::new("timeman-entropy-target", Spin::<UciPercent>::new(_ratio(0.60), _ratio(0.), _ratio(1.))),
+                timeman_movestreak_target: ConfigOption::new("timeman-movestreak-target", Spin::new(5, 0, 10)),
                 id_nmp_reduction: ConfigOption::new("id-nmp-reduction", Spin::new(2, 0, 10)),
                 id_nmp_phase_threshold: ConfigOption::new("id-nmp-phase-threshold", Spin::new(8, 0, 24)),
                 id_nmp_depth_factor: ConfigOption::new("id-nmp-depth-factor", Spin::new(3, 1, 20)),
@@ -376,6 +380,8 @@ impl Configuration {
             },
         }
     }
+
+    pub fn timeman_movestreak_target(&self) -> u32 { todo!() }
 }
 
 #[derive(Debug, Clone)]
@@ -423,7 +429,9 @@ impl ConfigBuilder {
     #[rustfmt::skip]
     pub fn chrono(mut self, params: &impl ChronoParams) -> Self {
         let cfg = &mut self.config;
+        #[allow(deprecated)]
         cfg.timeman_entropy_target.seed(Ratio::new::<ratio>(params.entropy_target().v()));
+        cfg.timeman_movestreak_target.seed(params.movestreak_target() as i32);
         self
     }
 

--- a/engine/src/core/params.rs
+++ b/engine/src/core/params.rs
@@ -77,6 +77,7 @@ pub type TunableParamsRef<B> = std::rc::Rc<TunableParams<B>>;
 #[derive(Debug, Clone)]
 pub struct TunableParams<Base> {
     timeman_entropy_target: NormalizedEntropy,
+    timeman_movestreak_target: u32,
     hce_policy_temp: f32,
     hce_q_futility_margin: i32,
     hce_q_delta_pruning_threshold: TaperValue,
@@ -113,6 +114,7 @@ impl<B, X: Deref<Target = TunableParams<B>>> PolicyParams for X {
 
 impl<B, X: Deref<Target = TunableParams<B>>> ChronoParams for X {
     fn entropy_target(&self) -> NormalizedEntropy { self.timeman_entropy_target }
+    fn movestreak_target(&self) -> u32 { self.timeman_movestreak_target }
 }
 
 impl<B, X: Deref<Target = TunableParams<B>>> IdParams for X {
@@ -127,6 +129,7 @@ impl<B> TunableParams<B> {
     fn from_config<C: Deref<Target = Configuration>>(config: C) -> Self {
         let config = config.deref();
         let timeman_entropy_target = config.timeman_entropy_target();
+        let timeman_movestreak_target = config.timeman_movestreak_target();
         let hce_policy_temp = config.eval_policy_temperature();
         let hce_q_futility_margin = config.eval_futility_margin();
         let hce_q_delta_pruning_threshold = config.eval_delta_pruning_threshold();
@@ -141,6 +144,7 @@ impl<B> TunableParams<B> {
         let id_nmp_margin = config.id_nmp_margin();
         Self {
             timeman_entropy_target,
+            timeman_movestreak_target,
             hce_policy_temp,
             hce_q_futility_margin,
             hce_q_delta_pruning_threshold,
@@ -287,6 +291,7 @@ impl IConfigBuilder for C_IdHceParams {
 
 impl const ChronoParams for C_IdHceParams {
     fn entropy_target(&self) -> NormalizedEntropy { NormalizedEntropy::new_c(0.55) }
+    fn movestreak_target(&self) -> u32 { 6 }
 }
 
 impl const QSearchParams for C_IdHceParams {
@@ -315,6 +320,7 @@ impl IConfigBuilder for C_IdNnueParams {
 
 impl const ChronoParams for C_IdNnueParams {
     fn entropy_target(&self) -> NormalizedEntropy { NormalizedEntropy::new_c(0.55) }
+    fn movestreak_target(&self) -> u32 { 4 }
 }
 
 impl const QSearchParams for C_IdNnueParams {
@@ -325,7 +331,7 @@ impl const QSearchParams for C_IdNnueParams {
 impl const IdParams for C_IdNnueParams {
     fn nmp_reduction(&self) -> Depth { Depth::new(2) }
     fn nmp_phase_threshold(&self) -> TaperValue { TaperValue::new(12) }
-    fn nmp_depth_factor(&self) -> u8 { 3 }
+    fn nmp_depth_factor(&self) -> u8 { 6 }
     fn nmp_phase_factor(&self) -> u32 { 7 }
     fn nmp_margin(&self) -> i32 { -100 }
 }

--- a/engine/src/core/search/id/mod.rs
+++ b/engine/src/core/search/id/mod.rs
@@ -167,6 +167,9 @@ pub struct SearchStats {
 
     /// Entropy of the last completed iteration.
     pub root_entropy: NormalizedEntropy,
+
+    /// Number of times the best move has been the best move in a row.
+    pub root_movestreak: u32,
 }
 
 impl Default for SearchStats {
@@ -177,6 +180,7 @@ impl Default for SearchStats {
             iter_time: Duration::ZERO,
             // Max uncertainty until a policy is computed
             root_entropy: NormalizedEntropy::one(),
+            root_movestreak: 0,
         }
     }
 }
@@ -203,6 +207,7 @@ pub fn go(
     let mut searcher = Searcher::new(pos, limit, ct, tt, eval);
     let mut stats = SearchStats::default();
     let mut best_move = None;
+    let mut last_best_move;
 
     for depth in (Depth::ROOT + 1)..=depth_lim {
         let best_score = searcher.search_root(params.clone(), pos, &mut stats, depth);
@@ -212,6 +217,8 @@ pub fn go(
         if searcher.aborted {
             break;
         }
+
+        last_best_move = searcher.root_best_move();
 
         searcher.sort_root();
 
@@ -228,10 +235,16 @@ pub fn go(
             let root_policy = math::softmax(root_logits, ROOT_ENTROPY_TEMP, &mut List::new());
             math::normalized_entropy(&root_policy)
         };
+        stats.root_movestreak = if best_move == last_best_move {
+            stats.root_movestreak + 1
+        }
+        else {
+            0
+        };
 
         searcher.time_man.hint_time_target(searcher.time_man.time_limit() - stats.iter_time);
-        searcher.time_man.hint_entropy_target(params.entropy_target());
-        searcher.time_man.set_curr_entropy(stats.root_entropy);
+        searcher.time_man.hint_movestreak_target(params.movestreak_target());
+        searcher.time_man.set_curr_movestreak(stats.root_movestreak);
 
         if searcher.should_stop(&stats) || searcher.time_man.reached_target() {
             break;
@@ -241,6 +254,7 @@ pub fn go(
     best_move
 }
 
+#[derive(Debug)]
 struct RootStats {
     mov: ScoredMove,
 }


### PR DESCRIPTION
Score of ccbench/in/builds/nephrid-2c9b5b9 vs
ccbench/in/builds/nephrid-c852fa6: 492 - 249 - 787  [0.580] 1528
...      ccbench/in/builds/nephrid-2c9b5b9 playing White: 260 - 112 -
392  [0.597] 764
...      ccbench/in/builds/nephrid-2c9b5b9 playing Black: 232 - 137 -
395  [0.562] 764
...      White vs Black: 397 - 344 - 787  [0.517] 1528
Elo difference: 55.7 +/- 12.1, LOS: 100.0 %, DrawRatio: 51.5 %
SPRT: llr 2.94 (100.0%), lbound -2.94, ubound 2.94 - H1 was accepted

Player: ccbench/in/builds/nephrid-2c9b5b9
   "Draw by 3-fold repetition": 761
   "Draw by fifty moves rule": 2
   "Draw by insufficient mating material": 24
   "Loss: Black mates": 112
   "Loss: White mates": 137
   "No result": 5
   "Win: Black mates": 232
   "Win: White mates": 260
Player: ccbench/in/builds/nephrid-c852fa6
   "Draw by 3-fold repetition": 761
   "Draw by fifty moves rule": 2
   "Draw by insufficient mating material": 24
   "Loss: Black mates": 232
   "Loss: White mates": 260
   "No result": 5
   "Win: Black mates": 112
   "Win: White mates": 137
Finished match