### PR TITLE
ID pondering

### DIFF
--- a/benchmarking/benches/id.rs
+++ b/benchmarking/benches/id.rs
@@ -50,7 +50,7 @@ where
     let mut eval = E::default();
     let mut timeman = TimeMan::<X>::new_with_limits(&limit, pos, params.clone());
 
-    id::go::<X>(pos, limit, &mut timeman, &debug, ct, &mut tt, &mut hh, &mut eval, params);
+    id::go::<X>(pos, limit, &mut timeman, &debug, ct, &mut tt, &mut hh, &mut eval, None, params);
 }
 
 pub fn id_hce_nps(c: &mut Criterion) {

--- a/engine/src/core/chrono.rs
+++ b/engine/src/core/chrono.rs
@@ -109,12 +109,17 @@ where
 
     pub fn new_with_limits(limit: &UciLimit, pos: &Position, params: X::Ref) -> Self {
         let mut new = Self::new(params);
-        new.init_limits(limit, pos);
+        new.init_limits(limit, pos.get_turn());
         new
     }
 
-    pub fn init_limits(&mut self, limit: &UciLimit, pos: &Position) {
-        let time_per_move = Self::time_per_move(limit, pos.get_turn());
+    pub fn start_search(&mut self) {
+        self.time_start = Some(Instant::now());
+        self.limits = HardLimits { time: None };
+    }
+
+    pub fn init_limits(&mut self, limit: &UciLimit, turn: Turn) {
+        let time_per_move = Self::time_per_move(limit, turn);
         let time_start = Instant::now();
         let time_limit = time_start + time_per_move;
 

--- a/engine/src/core/search/id/mod.rs
+++ b/engine/src/core/search/id/mod.rs
@@ -35,6 +35,7 @@ use crate::{
         ply::Ply,
         position::{CheckState, PieceInfo, PieceInfoObserver, Position},
         search::{
+            PonderToken,
             data::{
                 self, HistoryScore, Line, PieceHistories, RbSet, SearchStack, THistoryScore, TTBound, TTDepth, TTKey, TTMove, TTScore, TTStaticEval,
                 TranspositionTable,
@@ -44,7 +45,7 @@ use crate::{
             ordering::{self, MovePicker, MoveScore, MoveScorer, RtStage, ScoredMove, Stage},
             quiesce::{self, QSearchParams, QSearcher},
             score::{AnyScore, Cp, Score, scores},
-            strat::{UciArg, UciCp, UciCurrmove, UciDepth, UciNodes, UciNps, UciPv, UciScore, UciSearchtime, UciSeldepth},
+            strat::{UciArg, UciCp, UciCurrmove, UciDepth, UciNodes, UciNps, UciPondermove, UciPv, UciScore, UciSearchtime, UciSeldepth},
             tree::{NodeKind, NodeType, node_types::*},
         },
         turn::Turn,
@@ -220,6 +221,12 @@ pub const trait IdParams {
     fn aw_margin(&self) -> AnyScore { hce::piece_score(piece_type::PAWN) / 4 }
 }
 
+#[derive(Default)]
+pub struct SearchResult {
+    pub best_move: Option<Move>,
+    pub pv: Line,
+}
+
 pub fn go<X: IParams>(
     pos: &mut Position,
     limit: UciLimit,
@@ -229,8 +236,9 @@ pub fn go<X: IParams>(
     tt: &mut TT,
     hh: &mut HH,
     eval: &mut impl StaticEvaluator,
+    ponder: Option<PonderToken>,
     params: X::Ref,
-) -> Option<Move>
+) -> SearchResult
 where
     X::Ref: ChronoParams + QSearchParams + ScorerParams + IdParams + Clone + fmt::Debug,
 {
@@ -242,7 +250,7 @@ where
         println!("info string Starting ID Search with Params: {params:?}");
     }
 
-    let mut searcher = Searcher::<_, X>::new(pos, limit, timeman, ct, tt, hh, eval, params.clone());
+    let mut searcher = Searcher::<_, X>::new(pos, limit, timeman, ct, tt, hh, eval, params.clone(), ponder);
     let mut stats = SearchStats::default();
     let mut best_move = None;
     let mut last_best_move;
@@ -302,7 +310,10 @@ where
         }
     }
 
-    best_move
+    SearchResult {
+        best_move,
+        pv: searcher.pv().clone(),
+    }
 }
 
 #[derive(Debug)]
@@ -330,10 +341,12 @@ impl RootStats {
 struct Searcher<'a, 'b, E: StaticEvaluator, X: IParams> {
     root_stats: List<{ MAX_LEGAL_MOVES }, RootStats>,
     root_ply: Ply,
+    root_turn: Turn,
     limit: UciLimit,
     timeman: &'a mut TimeMan<X>,
     ct: CancellationToken,
     aborted: bool,
+    ponder: Option<PonderState>,
     ss: SS,
     tt: &'a mut TT,
     hh: &'a mut HH,
@@ -341,6 +354,16 @@ struct Searcher<'a, 'b, E: StaticEvaluator, X: IParams> {
     params: X::Ref,
     #[cfg(feature = "id-nmp")]
     in_nmp_verify: bool,
+}
+
+#[derive(Debug, Clone)]
+struct PonderState {
+    token: PonderToken,
+    is_not_pondering: bool,
+}
+
+impl PonderState {
+    fn new(token: PonderToken) -> Self { Self { token, is_not_pondering: false } }
 }
 
 impl<'a, 'b, E: StaticEvaluator, X: IParams> Searcher<'a, 'b, E, X>
@@ -356,6 +379,7 @@ where
         hh: &'a mut HH,
         eval: &'b mut E,
         params: X::Ref,
+        ponder: Option<PonderToken>,
     ) -> Self {
         let mut stats = List::<{ MAX_LEGAL_MOVES }, RootStats>::new();
         _ = fold_moves::<AllLegal, _, _, _>(pos, (), |_, m| {
@@ -366,10 +390,12 @@ where
         Self {
             root_stats: stats,
             root_ply: pos.ply(),
+            root_turn: pos.get_turn(),
             limit,
             timeman,
             ct,
             aborted: false,
+            ponder: ponder.map(PonderState::new),
             ss: SS::from(vec![SearchEntry {
                 phase: TaperValue::from_position(pos.piece_info()),
                 ..Default::default()
@@ -398,13 +424,26 @@ where
         root_logits
     }
 
-    fn should_stop(&self, stats: &SearchStats) -> bool {
+    fn should_stop(&mut self, stats: &SearchStats) -> bool {
         let nodes = stats.nodes;
         let iters = stats.iterations;
 
         // user requested stop
         if self.ct.is_cancelled() {
             return true;
+        }
+
+        // if we are pondering: check if we should still be pondering and if not, turn
+        // on the limits.
+        if let Some(ponder) = &mut self.ponder
+            && !ponder.is_not_pondering
+        {
+            if ponder.token.should_ponder() {
+                return false;
+            }
+
+            self.timeman.init_limits(&self.limit, self.root_turn);
+            ponder.is_not_pondering = true;
         }
 
         // time manager says we should stop or limit has been reached
@@ -1155,6 +1194,11 @@ fn uci_info(depth: Depth, stats: &SearchStats, best_score: AnyScore, best_move: 
     let string = UciArg::<String>::None;
 
     println!("info{currmove}{score}{nodes}{nps}{depth}{seldepth}{time}{pv}{string}");
+}
+
+pub fn uci_bestmove(best_move: Move, pv: &Line) {
+    let ponder_move = UciArg::from(pv.get(1).copied().map(UciPondermove));
+    println!("bestmove {best_move}{ponder_move}");
 }
 
 pub type DepthExt = FractionalDepth;

--- a/engine/src/core/search/id/mod.rs
+++ b/engine/src/core/search/id/mod.rs
@@ -252,7 +252,10 @@ where
 
     let mut searcher = Searcher::<_, X>::new(pos, limit, timeman, ct, tt, hh, eval, params.clone(), ponder);
     let mut stats = SearchStats::default();
-    let mut best_move = None;
+    let mut result = SearchResult {
+        best_move: None,
+        pv: Line::default(),
+    };
     let mut last_best_move;
     let root_tt_entry = searcher.tt.get(pos.get_key()).cloned();
     let mut curr_score = root_tt_entry.as_ref().map(|e| e.score).unwrap_or(scores::ZERO);
@@ -277,11 +280,14 @@ where
 
         searcher.sort_root();
 
-        best_move = searcher.root_best_move();
-        if let Some(best_move) = best_move
+        result.best_move = searcher.root_best_move();
+        result.pv = searcher.pv().clone();
+
+        // uci info output
+        if let Some(best_move) = result.best_move
             && let Some(search_time) = searcher.timeman.elapsed_search_time()
         {
-            uci_info(depth, &stats, curr_score, best_move, search_time, searcher.pv());
+            uci_info(depth, &stats, curr_score, best_move, search_time, &result.pv);
         }
 
         // update stats
@@ -293,7 +299,7 @@ where
             let root_policy = math::softmax(root_logits, ROOT_ENTROPY_TEMP, &mut List::new());
             math::normalized_entropy(&root_policy)
         };
-        stats.root_movestreak = if best_move == last_best_move {
+        stats.root_movestreak = if result.best_move == last_best_move {
             stats.root_movestreak + 1
         }
         else {
@@ -310,10 +316,7 @@ where
         }
     }
 
-    SearchResult {
-        best_move,
-        pv: searcher.pv().clone(),
-    }
+    result
 }
 
 #[derive(Debug)]

--- a/engine/src/core/search/id/test.rs
+++ b/engine/src/core/search/id/test.rs
@@ -31,6 +31,7 @@ fn run_search(fen: &str, depth: u8) {
         &mut tt,
         &mut hh,
         &mut HceEvaluator,
+        None,
         C_IdHceParams,
     );
 }

--- a/engine/src/core/search/mcts/strategy.rs
+++ b/engine/src/core/search/mcts/strategy.rs
@@ -192,7 +192,7 @@ where
         self.terminal_nodes_begin = tree.terminal_nodes() as u64;
         self.iterations = 0;
 
-        self.time_man.init_limits(&self.limit, pos);
+        self.time_man.init_limits(&self.limit, pos.get_turn());
         self.is_not_pondering = self.pt.is_none();
     }
 

--- a/engine/src/core/search/mod.rs
+++ b/engine/src/core/search/mod.rs
@@ -131,9 +131,9 @@ where
                 // probably just do it on the fly in AdvanceState...
                 self.eval.init(pos.piece_info());
 
-                self.timeman.init_limits(&limit, &pos);
+                self.timeman.init_limits(&limit, pos.get_turn());
 
-                let best_move = id::go::<X>(
+                let result = id::go::<X>(
                     &mut pos,
                     limit,
                     &mut self.timeman,
@@ -142,17 +142,39 @@ where
                     &mut self.tt,
                     &mut self.hh,
                     &mut self.eval,
+                    None,
                     self.params.clone(),
                 );
 
-                if let Some(mov) = best_move {
-                    println!("bestmove {mov}");
+                if let Some(mov) = result.best_move {
+                    id::uci_bestmove(mov, &result.pv);
                 }
 
                 Ok(())
             }
-            Command::Ponder(_pos, _limit, _ct, _dbg, _ponder) => {
-                todo!()
+            Command::Ponder(mut pos, limit, ct, debug, ponder) => {
+                self.eval.init(pos.piece_info());
+
+                self.timeman.start_search();
+
+                let result = id::go::<X>(
+                    &mut pos,
+                    limit,
+                    &mut self.timeman,
+                    &debug,
+                    ct,
+                    &mut self.tt,
+                    &mut self.hh,
+                    &mut self.eval,
+                    Some(ponder),
+                    self.params.clone(),
+                );
+
+                if let Some(mov) = result.best_move {
+                    id::uci_bestmove(mov, &result.pv);
+                }
+
+                Ok(())
             }
             Command::AdvanceState(_) => {
                 // no need to update the tt, the depth will be the same

--- a/nephrid/tests/integration_tests.rs
+++ b/nephrid/tests/integration_tests.rs
@@ -354,6 +354,96 @@ pub mod ponder_tests {
     }
 }
 
+#[cfg(test)]
+#[cfg(any(feature = "id-hce", feature = "id-nnue"))]
+pub mod id_ponder_tests {
+    use super::*;
+
+    fn extract_nodes(line: &str) -> Option<u64> {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if let Some(pos) = parts.iter().position(|&s| s == "nodes")
+            && pos + 1 < parts.len()
+        {
+            return parts[pos + 1].parse::<u64>().ok();
+        }
+        None
+    }
+
+    #[test]
+    #[timeout(10000)]
+    fn test_ponder_stop_outputs_ponder_move() {
+        let mut child = GuardedChild(
+            Command::cargo_bin("nephrid")
+                .unwrap()
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .spawn()
+                .expect("Failed to spawn engine binary"),
+        );
+
+        let mut stdin = child.stdin.take().expect("Failed to open stdin");
+        let stdout = child.stdout.take().expect("Failed to open stdout");
+        let mut reader = BufReader::new(stdout);
+
+        write_engine_line(&mut stdin, "uci");
+        block_engine_line(&mut reader, |l| l == "uciok");
+
+        write_engine_line(&mut stdin, "isready");
+        block_engine_line(&mut reader, |l| l == "readyok");
+
+        write_engine_line(&mut stdin, "position startpos");
+        write_engine_line(&mut stdin, "go ponder nodes 500000");
+
+        block_engine_line(&mut reader, |l| {
+            l.starts_with("info") && l.split_once(" pv ").is_some_and(|(_, pv)| pv.split_whitespace().count() >= 2)
+        });
+
+        write_engine_line(&mut stdin, "stop");
+
+        let bestmove_line = block_engine_line(&mut reader, |l| l.starts_with("bestmove"));
+        assert!(bestmove_line.contains("ponder"), "Expected a ponder move in bestmove output: {bestmove_line}");
+
+        write_engine_line(&mut stdin, "quit");
+    }
+
+    #[test]
+    #[timeout(10000)]
+    fn test_ponderhit_applies_limits_and_stops() {
+        let mut child = GuardedChild(
+            Command::cargo_bin("nephrid")
+                .unwrap()
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .spawn()
+                .expect("Failed to spawn engine"),
+        );
+
+        let mut stdin = child.stdin.take().unwrap();
+        let stdout = child.stdout.take().unwrap();
+        let mut reader = BufReader::new(stdout);
+
+        write_engine_line(&mut stdin, "uci");
+        block_engine_line(&mut reader, |l| l == "uciok");
+
+        write_engine_line(&mut stdin, "isready");
+        block_engine_line(&mut reader, |l| l == "readyok");
+
+        write_engine_line(&mut stdin, "position startpos moves e2e4 e7e5");
+        write_engine_line(&mut stdin, "go ponder nodes 500");
+
+        block_engine_line(&mut reader, |l| {
+            l.starts_with("info") && extract_nodes(l).is_some_and(|nodes| nodes > 1000)
+        });
+
+        write_engine_line(&mut stdin, "ponderhit");
+
+        let bestmove_line = block_engine_line(&mut reader, |l| l.starts_with("bestmove"));
+        assert!(!bestmove_line.is_empty(), "Engine failed to stop on its own after ponderhit!");
+
+        write_engine_line(&mut stdin, "quit");
+    }
+}
+
 #[test]
 #[timeout(10000)]
 fn test_pgn_input_command() {


### PR DESCRIPTION
ccbench against main with pondering:
```
Score of ccbench/in/builds/nephrid-b95ab5e vs
ccbench/in/builds/nephrid-fe91b47: 119 - 31 - 250  [0.610] 400
...      ccbench/in/builds/nephrid-b95ab5e playing White: 64 - 15 - 122 [0.622] 201
...      ccbench/in/builds/nephrid-b95ab5e playing Black: 55 - 16 - 128 [0.598] 199
...      White vs Black: 80 - 70 - 250  [0.512] 400
Elo difference: 77.7 +/- 20.4, LOS: 100.0 %, DrawRatio: 62.5 %
SPRT: llr 1.57 (53.2%), lbound -2.94, ubound 2.94
```

ccbench against main without pondering:
```
Score of ccbench/in/builds/nephrid-c57ed44 vs ccbench/in/builds/nephrid-fe91b47: 327 - 314 - 909  [0.504] 1550
...      ccbench/in/builds/nephrid-c57ed44 playing White: 179 - 152 - 443  [0.517] 774
...      ccbench/in/builds/nephrid-c57ed44 playing Black: 148 - 162 - 466  [0.491] 776
...      White vs Black: 341 - 300 - 909  [0.513] 1550
Elo difference: 2.9 +/- 11.1, LOS: 69.6 %, DrawRatio: 58.6 %
SPRT: llr 0.119 (4.0%), lbound -2.94, ubound 2.94
```